### PR TITLE
Rm new task bug

### DIFF
--- a/src/scripts/IDObject.js
+++ b/src/scripts/IDObject.js
@@ -1,0 +1,22 @@
+//app to hold incrimenting id counter
+const IDCounter = Object.create({}, {
+    currentID: {
+        value: 1,
+        writable: true,
+        enumerable: true,
+    },
+    saveID: {
+        value: function() {
+            localStorage.setItem("ID", JSON.stringify(this.currentID))
+        }
+    },
+    loadID: {
+        value: function() {
+            if (localStorage.getItem("Tasks") !== null) {
+                this.currentID = JSON.parse(localStorage.getItem("ID"))
+            }
+        }
+    }
+})
+
+module.exports = IDCounter

--- a/src/scripts/clearParentElement.js
+++ b/src/scripts/clearParentElement.js
@@ -1,0 +1,9 @@
+//function to clear everything inside the article tags of the dom
+const nukeElement = (element) => {
+    const article = document.querySelector(element)
+    while (article.firstChild) {
+        article.removeChild(article.firstChild)
+    }
+}
+
+module.exports = nukeElement

--- a/src/scripts/taskFactory.js
+++ b/src/scripts/taskFactory.js
@@ -3,17 +3,18 @@
 const Tasks = require("./Tasks")
 const saveDatabase = require("./databaseSave")
 const timestamp = require("./timestamp")
+const IDCounter = require("./IDObject")
 
-const idGenerator = function* (startFrom = 0) {
-	let newId = 1
+// const idGenerator = function* (startFrom = 0) {
+// 	let newId = 1
 
-	while (true) {
-		yield startFrom + newId
-		newId++
-	}
-}
+// 	while (true) {
+// 		yield startFrom + newId
+// 		newId++
+// 	}
+// }
 
-const uuidMaker = idGenerator()
+// const uuidMaker = idGenerator()
 
 
 //factory function to create new tasks when called
@@ -60,8 +61,11 @@ const createNewTask = (title, description, dueDate, status, category) => {
 			writable: true
 		}
 	})
-	//stores the next unique id in a variable
-	let taskUID = "_" + uuidMaker.next().value
+    //stores the next unique id in a variable
+    IDCounter.loadID()
+    let taskUID = "_" + IDCounter.currentID
+    IDCounter.currentID++
+    IDCounter.saveID()
 
 
 	//creates a key in the master database object using the unique id as the key name


### PR DESCRIPTION
Added a new object called IDCounter that keeps track of the next id to be used on a new task. The create new task function now loads this number from local storage, uses it, and then saves it back into local storage.

```
git fetch --all
git checkout rm-new-task-bug
```

1. wipe your current local storage for this project.
1. refresh page.
1. create new task.
1. check local storage, it should have two new items, one named ID and one named Tasks
1. refresh page again
1. create new task, make sure this task does not overwrite the previous task
1. repeat 4-6 a few times