### PR TITLE
fixed bug where new tasks were not immediately tagged as overdue

### DIFF
--- a/src/scripts/dropEventHandler.js
+++ b/src/scripts/dropEventHandler.js
@@ -8,7 +8,7 @@ const handleDrop = (dropArea, draggedElement) => {
     const card = draggedElement.draggable[0]
     const newStatus = dropArea.target.getAttribute("id")
     const column = dropArea.target
-    overdue(taskID)
+    overdue(TaskDatabase.tasks[taskID])
     if (newStatus !== "toDo") {
         console.log(TaskDatabase.tasks[taskID].status)
         TaskDatabase.tasks[taskID].status = newStatus

--- a/src/scripts/overdue.js
+++ b/src/scripts/overdue.js
@@ -4,14 +4,14 @@
 const TaskDatabase = require("./Tasks")
 
 const checkIfOverdue = (task) => {
-	const taskToCheck = TaskDatabase.tasks[task]
-	const dueDate = Date.parse(taskToCheck.dueDate)
+	const dueDate = Date.parse(task.dueDate)
 	const dateNow = Date.parse(new Date().toString())
-	console.log(dueDate,dateNow)
 	if (dateNow - dueDate > 0) {
-		taskToCheck.overdue = true
+		task.overdue = true
+		return true
 	} else if (dateNow - dueDate < 0) {
-		taskToCheck.overdue = false
+		task.overdue = false
+		return false
 	}
 }
 

--- a/src/scripts/taskFactory.js
+++ b/src/scripts/taskFactory.js
@@ -4,7 +4,7 @@ const TaskDatabase = require("./Tasks")
 const saveDatabase = require("./databaseSave")
 const timestamp = require("./timestamp")
 const IDCounter = require("./IDObject")
-
+const overdue = require("./overdue")
 
 
 //factory function to create new tasks when called
@@ -51,6 +51,10 @@ const createNewTask = (title, description, dueDate, status, category) => {
 			writable: true
 		}
 	})
+
+	//run overdue check
+	overdue(newTask)
+
     //stores the next unique id in a variable
     IDCounter.loadID()
     let taskUID = "_" + IDCounter.currentID


### PR DESCRIPTION
new tasks are now being correctly tagged as overdue and no longer require page refreshing.

```
git fetch --all
git checkout rm-fix-overdue-tag
```

1. create new task
1. make sure task is tagged as overdue in storage and on the page